### PR TITLE
Fixed 'unable to reload post-processor' error due to variable scope bug

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -153,12 +153,15 @@ function requestPostReload() {
     readFile.close();
   
     // write the source back to the file
+    let writeFile;
     try {
-      const writeFile = new TextFile(getConfigurationPath(), true, 'ansi');
+      writeFile = new TextFile(getConfigurationPath(), true, 'ansi');
       for (let i = 0; i < lines.length; i++) 
         writeFile.write(lines[i] + '\n');
     } finally {
-      writeFile.close();
+      if (writeFile) {
+        writeFile.close();
+      }
     }
   } catch (ex) {
     showWarning(localize('Unable to reload post-processor; please exit and restart the application (e.g. Fusion 360).  (error {error}'),


### PR DESCRIPTION
I've been getting this error every time I've run "Post Process":

```
Unable to reload post-processor; please exit and restart the application (e.g. Fusion 360). (error writeFile is not defined
```

<img width="327" alt="Screenshot 2024-09-12 180236" src="https://github.com/user-attachments/assets/821b567e-616c-410d-9cba-8febe0e3a418">

The error doesn't prevent the `.ltrn` file from being generated. It all works fine despite the message.

I've seen this error in Version 1.2.0 and also in a version I've built from the `main` branch.

I think this is due to the `const writeFile = ...` being declared within the `try` block which makes it out of scope of the `finally` block. 

With this change, the error message no longer appears. 

It's been years since I've touched JS code. There might be smarter ways to fix this.

